### PR TITLE
Enabling multi-arch for arm64 and amd64, and removing images from stacks

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,9 +1,23 @@
 description = "Static base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with no buildpacks included. To use, specify buildpacks at build time."
 
+[build]
+  image = "docker.io/paketobuildpacks/build-jammy-static:0.0.157"
+
 [lifecycle]
   version = "0.20.14"
 
 [stack]
-  build-image = "docker.io/paketobuildpacks/build-jammy-static:0.0.157"
   id = "io.buildpacks.stacks.jammy.static"
-  run-image = "index.docker.io/paketobuildpacks/run-jammy-static:latest"
+
+[run]
+  [[run.images]]
+    image = "index.docker.io/paketobuildpacks/run-jammy-static:latest"
+
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* enables multi-arch for arm64 and amd64
* Moves run and build images out of stacks table and into build and run tables

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
